### PR TITLE
Update load-secrets.sh to not try to rewrite /dev/null

### DIFF
--- a/workstation/scripts/load-secrets.sh
+++ b/workstation/scripts/load-secrets.sh
@@ -52,7 +52,7 @@ function MnemonicGenerator() {
         
         if [ ! -f "$keyidPath" ] || [ ! -f "$nodekeyPath" ] ; then # node keys are only re-generated if any of keystore files is not present
             rm -fv "$keyidPath" "$nodekeyPath"
-            priv-key-gen --mnemonic="$mnemonic" --valkey=/dev/null --nodekey="$nodekeyPath" --keyid="$keyidPath"
+            priv-key-gen --mnemonic="$mnemonic" --valkey=/tmp/temp_valkey.tmp --nodekey="$nodekeyPath" --keyid="$keyidPath"
         fi
     
         newNodeId=$(cat $keyidPath)


### PR DESCRIPTION
Current version will generate error because it tries to rewrite /dev/null
panic: rename /dev/write-file-atomic-02523233146853525413 /dev/null: device or resource busy

I think we do not need to use /dev/null as destination to --valkey